### PR TITLE
feat(web): add polished footer and background styling

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -27,6 +27,7 @@
     @apply min-h-screen antialiased text-gray-800 dark:text-gray-100;
     background: radial-gradient(1200px 600px at 10% -10%, rgba(124,58,237,0.12), rgba(124,58,237,0) 60%),
                 radial-gradient(1200px 600px at 90% 10%, rgba(99,102,241,0.12), rgba(99,102,241,0) 60%),
+                radial-gradient(1200px 600px at 50% 110%, rgba(34,197,94,0.08), rgba(34,197,94,0) 60%),
                 rgb(var(--bg));
   }
 
@@ -37,7 +38,7 @@
   .container-page { @apply container mx-auto; }
 
   .section-title {
-    @apply text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100;
+    @apply text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100 font-display;
   }
 
   .navbar {
@@ -94,4 +95,17 @@
 
   .gradient-text { @apply bg-clip-text text-transparent bg-gradient-to-r from-primary-600 to-brand-500; }
   .glass { @apply bg-white/70 dark:bg-neutral-900/60 backdrop-blur border border-white/20 dark:border-neutral-800; }
+
+  .footer {
+    @apply relative glass;
+  }
+  .footer::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 2px;
+    width: 100%;
+    background-image: linear-gradient(to right, theme('colors.primary.600'), theme('colors.brand.500'), theme('colors.accent.500'));
+  }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from 'next/font/google';
 import './globals.css';
 import { Providers } from './providers';
 import Navigation from '@/components/Navigation';
+import Footer from '@/components/Footer';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -22,6 +23,7 @@ export default function RootLayout({
         <Providers>
           <Navigation />
           {children}
+          <Footer />
         </Providers>
       </body>
     </html>

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+
+export default function Footer() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="footer">
+      <div className="container-page py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+        <p>
+          © {year} Neighborhood Hub. Built with <span aria-hidden="true">♥</span> for the community.
+        </p>
+        <p className="mt-2 font-display">
+          <span className="gradient-text font-semibold">Join, Connect, Grow</span>
+        </p>
+        <p className="mt-4 space-x-4">
+          <Link href="/services" className="link-primary">
+            Services
+          </Link>
+          <Link href="/market" className="link-primary">
+            Market
+          </Link>
+          <Link href="/polls" className="link-primary">
+            Polls
+          </Link>
+        </p>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- add a stylized site-wide footer component
- enrich global background with accent gradient and display headings
- wire footer into root layout for consistent presence

## Testing
- `pnpm --filter @neighborhood-hub/web lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68b74e6d0d4083299e86c82ce0361832