### PR TITLE
feat(web): add polished footer and background styling

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import PageHeader from '@/components/PageHeader';
 
 interface Community {
   id: string;
@@ -98,9 +99,9 @@ export default function AdminPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="container-page flex items-center justify-center py-16">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600 mx-auto"></div>
+          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-600 mx-auto" />
           <p className="mt-4 text-gray-600">Loading admin panel...</p>
         </div>
       </div>
@@ -108,47 +109,40 @@ export default function AdminPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="py-6">
-            <h1 className="text-3xl font-bold text-gray-900">Admin Panel</h1>
-            <p className="mt-2 text-gray-600">Manage communities and user account roles</p>
-          </div>
-        </div>
-      </div>
+    <div className="container-page py-8">
+      <PageHeader
+        title="Admin Panel"
+        description="Manage communities and user account roles"
+      />
 
       {/* Navigation */}
-      <div className="bg-white border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <nav className="flex space-x-8">
-            <button
-              onClick={() => setActiveTab('communities')}
-              className={`py-4 px-1 border-b-2 font-medium text-sm ${
-                activeTab === 'communities'
-                  ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-              }`}
-            >
-              Communities
-            </button>
-            <button
-              onClick={() => setActiveTab('users')}
-              className={`py-4 px-1 border-b-2 font-medium text-sm ${
-                activeTab === 'users'
-                  ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-              }`}
-            >
-              User Accounts
-            </button>
-          </nav>
-        </div>
+      <div className="card mb-8">
+        <nav className="flex space-x-8">
+          <button
+            onClick={() => setActiveTab('communities')}
+            className={`py-4 px-1 border-b-2 font-medium text-sm ${
+              activeTab === 'communities'
+                ? 'border-primary-600 text-primary-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+            }`}
+          >
+            Communities
+          </button>
+          <button
+            onClick={() => setActiveTab('users')}
+            className={`py-4 px-1 border-b-2 font-medium text-sm ${
+              activeTab === 'users'
+                ? 'border-primary-600 text-primary-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+            }`}
+          >
+            User Accounts
+          </button>
+        </nav>
       </div>
 
       {/* Content */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="py-8">
         {activeTab === 'communities' ? (
           <div>
             <div className="flex justify-between items-center mb-6">
@@ -159,7 +153,7 @@ export default function AdminPage() {
             </div>
 
             {communities.length > 0 ? (
-              <div className="bg-white shadow overflow-hidden rounded-lg">
+              <div className="card overflow-hidden">
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>
@@ -233,7 +227,7 @@ export default function AdminPage() {
             </div>
 
             {users.length > 0 ? (
-              <div className="bg-white shadow overflow-hidden rounded-lg">
+              <div className="card overflow-hidden">
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -27,6 +27,7 @@
     @apply min-h-screen antialiased text-gray-800 dark:text-gray-100;
     background: radial-gradient(1200px 600px at 10% -10%, rgba(124,58,237,0.12), rgba(124,58,237,0) 60%),
                 radial-gradient(1200px 600px at 90% 10%, rgba(99,102,241,0.12), rgba(99,102,241,0) 60%),
+                radial-gradient(1200px 600px at 50% 110%, rgba(34,197,94,0.08), rgba(34,197,94,0) 60%),
                 rgb(var(--bg));
   }
 
@@ -37,7 +38,7 @@
   .container-page { @apply container mx-auto; }
 
   .section-title {
-    @apply text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100;
+    @apply text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100 font-display;
   }
 
   .navbar {
@@ -94,4 +95,17 @@
 
   .gradient-text { @apply bg-clip-text text-transparent bg-gradient-to-r from-primary-600 to-brand-500; }
   .glass { @apply bg-white/70 dark:bg-neutral-900/60 backdrop-blur border border-white/20 dark:border-neutral-800; }
+
+  .footer {
+    @apply relative glass;
+  }
+  .footer::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 2px;
+    width: 100%;
+    background-image: linear-gradient(to right, theme('colors.primary.600'), theme('colors.brand.500'), theme('colors.accent.500'));
+  }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from 'next/font/google';
 import './globals.css';
 import { Providers } from './providers';
 import Navigation from '@/components/Navigation';
+import Footer from '@/components/Footer';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -22,6 +23,7 @@ export default function RootLayout({
         <Providers>
           <Navigation />
           {children}
+          <Footer />
         </Providers>
       </body>
     </html>

--- a/apps/web/src/app/market/page.tsx
+++ b/apps/web/src/app/market/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import PageHeader from '@/components/PageHeader';
 
 interface ListingPost {
   id: string;
@@ -98,9 +99,9 @@ export default function MarketPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="container-page flex items-center justify-center py-16">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600 mx-auto"></div>
+          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-600 mx-auto" />
           <p className="mt-4 text-gray-600">Loading marketplace...</p>
         </div>
       </div>
@@ -108,21 +109,15 @@ export default function MarketPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="py-6">
-            <h1 className="text-3xl font-bold text-gray-900">Community Marketplace</h1>
-            <p className="mt-2 text-gray-600">Buy, sell, and trade items with your neighbors</p>
-          </div>
-        </div>
-      </div>
+    <div className="container-page py-8">
+      <PageHeader
+        title="Community Marketplace"
+        description="Buy, sell, and trade items with your neighbors"
+      />
 
       {/* Filters */}
-      <div className="bg-white border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div className="card mb-8">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div>
               <label htmlFor="condition-filter" className="block text-sm font-medium text-gray-700 mb-2">
                 Condition
@@ -189,82 +184,80 @@ export default function MarketPage() {
       </div>
 
       {/* Listings Grid */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {listings.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {listings.map((listing) => (
-              <div key={listing.id} className="bg-white rounded-lg shadow overflow-hidden">
-                {/* Image Placeholder */}
-                <div className="h-48 bg-gray-200 flex items-center justify-center">
-                  {listing.images.length > 0 ? (
-                    <img
-                      src={listing.images[0]}
-                      alt={listing.title}
-                      className="w-full h-full object-cover"
-                    />
-                  ) : (
-                    <span className="text-gray-400 text-4xl">🏷️</span>
+      {listings.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {listings.map((listing) => (
+            <div key={listing.id} className="card overflow-hidden">
+              {/* Image Placeholder */}
+              <div className="h-48 bg-gray-200 flex items-center justify-center">
+                {listing.images.length > 0 ? (
+                  <img
+                    src={listing.images[0]}
+                    alt={listing.title}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <span className="text-gray-400 text-4xl">🏷️</span>
+                )}
+              </div>
+
+              <div className="p-6">
+                <div className="flex items-center gap-2 mb-3">
+                  {listing.extra.condition && (
+                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getConditionColor(listing.extra.condition)}`}>
+                      {listing.extra.condition}
+                    </span>
+                  )}
+                  {listing.extra.availability && (
+                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getAvailabilityColor(listing.extra.availability)}`}>
+                      {listing.extra.availability}
+                    </span>
                   )}
                 </div>
 
-                <div className="p-6">
-                  <div className="flex items-center gap-2 mb-3">
-                    {listing.extra.condition && (
-                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getConditionColor(listing.extra.condition)}`}>
-                        {listing.extra.condition}
-                      </span>
-                    )}
-                    {listing.extra.availability && (
-                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getAvailabilityColor(listing.extra.availability)}`}>
-                        {listing.extra.availability}
-                      </span>
-                    )}
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                  <Link href={`/c/${listing.community.slug}/posts/${listing.id}`} className="hover:text-primary-600">
+                    {listing.title}
+                  </Link>
+                </h3>
+
+                {listing.content && (
+                  <p className="text-gray-600 mb-4 line-clamp-2">{listing.content}</p>
+                )}
+
+                {listing.extra.price !== undefined && (
+                  <div className="text-2xl font-bold text-green-600 mb-3">
+                    ${listing.extra.price.toFixed(2)}
                   </div>
+                )}
 
-                  <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                    <Link href={`/c/${listing.community.slug}/posts/${listing.id}`} className="hover:text-blue-600">
-                      {listing.title}
-                    </Link>
-                  </h3>
+                <div className="flex items-center justify-between text-sm text-gray-500">
+                  <span>by {listing.author.fullName}</span>
+                  <span>{new Date(listing.createdAt).toLocaleDateString()}</span>
+                </div>
 
-                  {listing.content && (
-                    <p className="text-gray-600 mb-4 line-clamp-2">{listing.content}</p>
-                  )}
-
-                  {listing.extra.price !== undefined && (
-                    <div className="text-2xl font-bold text-green-600 mb-3">
-                      ${listing.extra.price.toFixed(2)}
-                    </div>
-                  )}
-
-                  <div className="flex items-center justify-between text-sm text-gray-500">
-                    <span>by {listing.author.fullName}</span>
-                    <span>{new Date(listing.createdAt).toLocaleDateString()}</span>
-                  </div>
-
-                  <div className="mt-3 text-sm text-gray-500">
-                    in {listing.community.name}
-                  </div>
+                <div className="mt-3 text-sm text-gray-500">
+                  in {listing.community.name}
                 </div>
               </div>
-            ))}
-          </div>
-        ) : (
-          <div className="text-center py-12">
-            <div className="text-6xl mb-4">🏷️</div>
-            <h3 className="text-xl font-medium text-gray-900 mb-2">No listings found</h3>
-            <p className="text-gray-600 mb-6">
-              {selectedCondition !== 'all' || selectedAvailability !== 'all' || priceRange.min > 0 || priceRange.max < 1000
-                ? 'Try adjusting your filters'
-                : 'No items have been listed for sale yet.'
-              }
-            </p>
-            <Link href="/" className="btn-primary">
-              Browse Communities
-            </Link>
-          </div>
-        )}
-      </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-12">
+          <div className="text-6xl mb-4">🏷️</div>
+          <h3 className="text-xl font-medium text-gray-900 mb-2">No listings found</h3>
+          <p className="text-gray-600 mb-6">
+            {selectedCondition !== 'all' || selectedAvailability !== 'all' || priceRange.min > 0 || priceRange.max < 1000
+              ? 'Try adjusting your filters'
+              : 'No items have been listed for sale yet.'
+            }
+          </p>
+          <Link href="/" className="btn-primary">
+            Browse Communities
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/polls/page.tsx
+++ b/apps/web/src/app/polls/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import PageHeader from '@/components/PageHeader';
 
 interface PollPost {
   id: string;
@@ -90,9 +91,9 @@ export default function PollsPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="container-page flex items-center justify-center py-16">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600 mx-auto"></div>
+          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-600 mx-auto" />
           <p className="mt-4 text-gray-600">Loading polls...</p>
         </div>
       </div>
@@ -100,115 +101,109 @@ export default function PollsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="py-6">
-            <h1 className="text-3xl font-bold text-gray-900">Community Polls</h1>
-            <p className="mt-2 text-gray-600">Vote on important community decisions</p>
-          </div>
-        </div>
-      </div>
+    <div className="container-page py-8">
+      <PageHeader
+        title="Community Polls"
+        description="Vote on important community decisions"
+      />
 
       {/* Filters */}
-      <div className="bg-white border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex flex-col sm:flex-row gap-4">
-            <div>
-              <label htmlFor="community-filter" className="block text-sm font-medium text-gray-700 mb-2">
-                Community
-              </label>
-              <select
-                id="community-filter"
-                value={selectedCommunity}
-                onChange={(e) => setSelectedCommunity(e.target.value)}
-                className="input-field max-w-xs"
-              >
-                <option value="all">All Communities</option>
-                {communities.map((community) => (
-                  <option key={community.id} value={community.id}>
-                    {community.name}
-                  </option>
-                ))}
-              </select>
-            </div>
+      <div className="card mb-8">
+        <div className="flex flex-col sm:flex-row gap-4">
+          <div>
+            <label
+              htmlFor="community-filter"
+              className="block text-sm font-medium text-gray-700 mb-2"
+            >
+              Community
+            </label>
+            <select
+              id="community-filter"
+              value={selectedCommunity}
+              onChange={(e) => setSelectedCommunity(e.target.value)}
+              className="input-field max-w-xs"
+            >
+              <option value="all">All Communities</option>
+              {communities.map((community) => (
+                <option key={community.id} value={community.id}>
+                  {community.name}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
       </div>
 
       {/* Polls List */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {polls.length > 0 ? (
-          <div className="space-y-6">
-            {polls.map((poll) => (
-              <div key={poll.id} className="bg-white rounded-lg shadow p-6">
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-3 mb-3">
-                      <span className="text-2xl">📊</span>
-                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getPollStatusColor(getPollStatus(poll))}`}>
-                        {getPollStatus(poll)}
-                      </span>
-                    </div>
-                    
-                    <h3 className="text-xl font-semibold text-gray-900 mb-2">
-                      <Link href={`/c/${poll.community.slug}/posts/${poll.id}`} className="hover:text-blue-600">
-                        {poll.title}
-                      </Link>
-                    </h3>
-                    
-                    {poll.content && (
-                      <p className="text-gray-600 mb-4">{poll.content}</p>
-                    )}
-                    
-                    {poll.extra.options && (
-                      <div className="mb-4">
-                        <p className="text-sm font-medium text-gray-700 mb-2">Options:</p>
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                          {poll.extra.options.map((option, index) => (
-                            <div key={index} className="text-sm text-gray-600 bg-gray-50 px-3 py-2 rounded">
-                              {option}
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    
-                    <div className="flex items-center justify-between text-sm text-gray-500">
-                      <div className="flex items-center gap-4">
-                        <span>by {poll.author.fullName}</span>
-                        <span>in {poll.community.name}</span>
-                      </div>
-                      <span>{new Date(poll.createdAt).toLocaleDateString()}</span>
-                    </div>
-                    
-                    {poll.extra.totalVotes !== undefined && (
-                      <div className="mt-3 text-sm text-gray-500">
-                        🗳️ {poll.extra.totalVotes} vote{poll.extra.totalVotes !== 1 ? 's' : ''}
-                      </div>
-                    )}
+      {polls.length > 0 ? (
+        <div className="space-y-6">
+          {polls.map((poll) => (
+            <div key={poll.id} className="card">
+              <div className="flex items-start justify-between">
+                <div className="flex-1">
+                  <div className="flex items-center gap-3 mb-3">
+                    <span className="text-2xl">📊</span>
+                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getPollStatusColor(getPollStatus(poll))}`}>
+                      {getPollStatus(poll)}
+                    </span>
                   </div>
+
+                  <h3 className="text-xl font-semibold text-gray-900 mb-2">
+                    <Link href={`/c/${poll.community.slug}/posts/${poll.id}`} className="hover:text-primary-600">
+                      {poll.title}
+                    </Link>
+                  </h3>
+
+                  {poll.content && (
+                    <p className="text-gray-600 mb-4">{poll.content}</p>
+                  )}
+
+                  {poll.extra.options && (
+                    <div className="mb-4">
+                      <p className="text-sm font-medium text-gray-700 mb-2">Options:</p>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                        {poll.extra.options.map((option, index) => (
+                          <div key={index} className="text-sm text-gray-600 bg-gray-50 px-3 py-2 rounded">
+                            {option}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  <div className="flex items-center justify-between text-sm text-gray-500">
+                    <div className="flex items-center gap-4">
+                      <span>by {poll.author.fullName}</span>
+                      <span>in {poll.community.name}</span>
+                    </div>
+                    <span>{new Date(poll.createdAt).toLocaleDateString()}</span>
+                  </div>
+
+                  {poll.extra.totalVotes !== undefined && (
+                    <div className="mt-3 text-sm text-gray-500">
+                      🗳️ {poll.extra.totalVotes} vote{poll.extra.totalVotes !== 1 ? 's' : ''}
+                    </div>
+                  )}
                 </div>
               </div>
-            ))}
-          </div>
-        ) : (
-          <div className="text-center py-12">
-            <div className="text-6xl mb-4">📊</div>
-            <h3 className="text-xl font-medium text-gray-900 mb-2">No polls found</h3>
-            <p className="text-gray-600 mb-6">
-              {selectedCommunity !== 'all'
-                ? 'No polls have been created in this community yet.'
-                : 'No polls have been created yet.'
-              }
-            </p>
-            <Link href="/" className="btn-primary">
-              Browse Communities
-            </Link>
-          </div>
-        )}
-      </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-12">
+          <div className="text-6xl mb-4">📊</div>
+          <h3 className="text-xl font-medium text-gray-900 mb-2">No polls found</h3>
+          <p className="text-gray-600 mb-6">
+            {selectedCommunity !== 'all'
+              ? 'No polls have been created in this community yet.'
+              : 'No polls have been created yet.'
+            }
+          </p>
+          <Link href="/" className="btn-primary">
+            Browse Communities
+          </Link>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/services/page.tsx
+++ b/apps/web/src/app/services/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import PageHeader from '@/components/PageHeader';
 
 interface ServicePost {
   id: string;
@@ -86,9 +87,9 @@ export default function ServicesPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="container-page flex items-center justify-center py-16">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600 mx-auto"></div>
+          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-600 mx-auto" />
           <p className="mt-4 text-gray-600">Loading services...</p>
         </div>
       </div>
@@ -96,68 +97,66 @@ export default function ServicesPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="py-6">
-            <h1 className="text-3xl font-bold text-gray-900">Community Services</h1>
-            <p className="mt-2 text-gray-600">Find and offer services in your neighborhood</p>
-          </div>
-        </div>
-      </div>
+    <div className="container-page py-8">
+      <PageHeader
+        title="Community Services"
+        description="Find and offer services in your neighborhood"
+      />
 
       {/* Filters */}
-      <div className="bg-white border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex flex-col sm:flex-row gap-4">
-            <div>
-              <label htmlFor="priority-filter" className="block text-sm font-medium text-gray-700 mb-2">
-                Priority
-              </label>
-              <select
-                id="priority-filter"
-                value={selectedPriority}
-                onChange={(e) => setSelectedPriority(e.target.value)}
-                className="input-field max-w-xs"
-              >
-                <option value="all">All Priorities</option>
-                <option value="URGENT">Urgent</option>
-                <option value="HIGH">High</option>
-                <option value="MEDIUM">Medium</option>
-                <option value="LOW">Low</option>
-              </select>
-            </div>
+      <div className="card mb-8">
+        <div className="flex flex-col sm:flex-row gap-4">
+          <div>
+            <label
+              htmlFor="priority-filter"
+              className="block text-sm font-medium text-gray-700 mb-2"
+            >
+              Priority
+            </label>
+            <select
+              id="priority-filter"
+              value={selectedPriority}
+              onChange={(e) => setSelectedPriority(e.target.value)}
+              className="input-field max-w-xs"
+            >
+              <option value="all">All Priorities</option>
+              <option value="URGENT">Urgent</option>
+              <option value="HIGH">High</option>
+              <option value="MEDIUM">Medium</option>
+              <option value="LOW">Low</option>
+            </select>
+          </div>
 
-            <div>
-              <label htmlFor="status-filter" className="block text-sm font-medium text-gray-700 mb-2">
-                Status
-              </label>
-              <select
-                id="status-filter"
-                value={selectedStatus}
-                onChange={(e) => setSelectedStatus(e.target.value)}
-                className="input-field max-w-xs"
-              >
-                <option value="all">All Statuses</option>
-                <option value="OPEN">Open</option>
-                <option value="IN_PROGRESS">In Progress</option>
-                <option value="COMPLETED">Completed</option>
-                <option value="CANCELLED">Cancelled</option>
-              </select>
-            </div>
+          <div>
+            <label
+              htmlFor="status-filter"
+              className="block text-sm font-medium text-gray-700 mb-2"
+            >
+              Status
+            </label>
+            <select
+              id="status-filter"
+              value={selectedStatus}
+              onChange={(e) => setSelectedStatus(e.target.value)}
+              className="input-field max-w-xs"
+            >
+              <option value="all">All Statuses</option>
+              <option value="OPEN">Open</option>
+              <option value="IN_PROGRESS">In Progress</option>
+              <option value="COMPLETED">Completed</option>
+              <option value="CANCELLED">Cancelled</option>
+            </select>
           </div>
         </div>
       </div>
 
       {/* Services List */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {services.length > 0 ? (
-          <div className="space-y-6">
-            {services.map((service) => (
-              <div key={service.id} className="bg-white rounded-lg shadow p-6">
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
+      {services.length > 0 ? (
+        <div className="space-y-6">
+          {services.map((service) => (
+            <div key={service.id} className="card">
+              <div className="flex items-start justify-between">
+                <div className="flex-1">
                     <div className="flex items-center gap-3 mb-3">
                       <span className="text-2xl">🤝</span>
                       <div className="flex gap-2">

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+
+export default function Footer() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="footer">
+      <div className="container-page py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+        <p>
+          © {year} Neighborhood Hub. Built with <span aria-hidden="true">♥</span> for the community.
+        </p>
+        <p className="mt-2 font-display">
+          <span className="gradient-text font-semibold">Join, Connect, Grow</span>
+        </p>
+        <p className="mt-4 space-x-4">
+          <Link href="/services" className="link-primary">
+            Services
+          </Link>
+          <Link href="/market" className="link-primary">
+            Market
+          </Link>
+          <Link href="/polls" className="link-primary">
+            Polls
+          </Link>
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/apps/web/src/components/PageHeader.tsx
+++ b/apps/web/src/components/PageHeader.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface PageHeaderProps {
+  title: string;
+  description?: string;
+}
+
+export default function PageHeader({ title, description }: PageHeaderProps) {
+  return (
+    <header className="text-center mb-8">
+      <h1 className="section-title">{title}</h1>
+      {description && (
+        <p className="mt-2 text-gray-600 dark:text-gray-400">{description}</p>
+      )}
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a stylized site-wide footer component
- enrich global background with accent gradient and display headings
- wire footer into root layout for consistent presence
- introduce reusable PageHeader component and apply consistent card layouts to Services, Market, Polls, and Admin pages

## Testing
- `pnpm --filter @neighborhood-hub/web lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68b74e6d0d4083299e86c82ce0361832